### PR TITLE
Bump Kibana container to 6.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# https://github.com/elastic/kibana-docker
+FROM docker.elastic.co/kibana/kibana-oss:6.3.2
+
+# Add your kibana plugins setup here
+# Example: RUN kibana-plugin install <name|url>


### PR DESCRIPTION
- 6.3.0 container removed
- bumps kibana to 6.3.2